### PR TITLE
Increasing websocket buffer size

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -55,6 +55,13 @@ ui_down={
  ]
 }
 
+[network]
+
+limits/websocket_client/max_in_buffer_kb=2048
+limits/websocket_client/max_out_buffer_kb=2048
+limits/websocket_server/max_in_buffer_kb=2048
+limits/websocket_server/max_out_buffer_kb=2048
+
 [rendering]
 
 quality/filters/anisotropic_filter_level=1


### PR DESCRIPTION
This is a temporary solution, kicking the can down the road.
A better solution for chunking large objects, or keeping them in sync between clients, should be implemented if this is not something that should happen automatically in-engine.

Increasing the input/output websocket size from 64Kb (or KB the documentation is unclear) to 2048.