### PR TITLE
auto set the server if this is the web client

### DIFF
--- a/main_menu.gd
+++ b/main_menu.gd
@@ -6,7 +6,9 @@ signal start_game()
 
 func _ready():
 	if not (OS.has_feature("dungeon_master") or OS.has_feature("editor")):
-		$VBoxContainer/VBoxContainer/Host.visible = false
+		$VBoxContainer/VBoxContainer/HostGame.visible = false
+		$VBoxContainer/VBoxContainer/IpAddress.visible = false
+		$VBoxContainer/VBoxContainer/IpAddress.text = "server.demetermine.com"
 
 	$VBoxContainer/Version.text = "Version: " + Version.id()
 


### PR DESCRIPTION
Remove confusion for players while we are in this alpha-state and auto-set the server address (and hide it).
This brings it back to feature parity with the version before the menu changes.
