### PR TITLE
adding a defined signal to object to remove warnings

### DIFF
--- a/object.gd
+++ b/object.gd
@@ -1,5 +1,7 @@
 extends StaticBody
 
+signal animation_finished
+
 var target_position = Vector2(1,1)
 var target_rotation = 0
 


### PR DESCRIPTION
Adding the animation_finished signal to object.gd to remove some warnings I saw popping up every time a character was moved.
